### PR TITLE
Makesure the searchInput field exists before setting it.

### DIFF
--- a/bento.js
+++ b/bento.js
@@ -61,7 +61,10 @@
         var needle = getParameter("onesearch");
         var needleInput = $("#oubento_searchForm input[id=searchInput]").val();
         needle = (needleInput) ? needleInput : needle;
-        document.getElementById("searchInput").value = needle;
+        if(needleInput) {
+          needleInput.value = needle;
+        }
+
         if (needle) {
             mySearches.forEach(function (srch) {
                 srch(needle);


### PR DESCRIPTION
Make sure the `searchInput` field exists before setting it.

## Motivation and Context
`bento.js` was throwing an error on pages that aren't the main one search form. 

## Status / Testing

Works on my machine. 